### PR TITLE
Added link of Angular Developer Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 - [awesome-tutorials](#awesome-tutorials)
   - [[ Angular 2.0 从0到1 ][1]](#-angular-20-%E4%BB%8E0%E5%88%B01-1)
-  - [[ Angular Developer Roadmap ][2]](https://roadmap.sh/angular)
+  - [ Angular Developer Roadmap ](https://roadmap.sh/angular)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 - [awesome-tutorials](#awesome-tutorials)
   - [[ Angular 2.0 从0到1 ][1]](#-angular-20-%E4%BB%8E0%E5%88%B01-1)
+  - [[ Angular Developer Roadmap ][2]](https://roadmap.sh/angular)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 


### PR DESCRIPTION
Hi @wpcfan,

I came across your repository [awesome-tutorials](https://github.com/wpcfan/awesome-tutorials) and found it to be a valuable resource for Angular enthusiasts.

While browsing through the repository, I noticed that it was missing links to any structured guides such as the famous ["Angular Developer Roadmap"](https://roadmap.sh/angular). I took the initiative to submit a ["Pull Request"](https://github.com/wpcfan/awesome-tutorials/pull/21) adding it in.

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz